### PR TITLE
Implement unique function.  Closes mpetrovich/dash#9

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ echo "Average male age is $avgMaleAge.";
 [toObject](docs/Operations.md#toobject),
 [unary](docs/Operations.md#unary)
 [union](docs/Operations.md#union),
+[unique](docs/Operations.md#unique),
 [values](docs/Operations.md#values)
 
 #### Jump to:

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ echo "Average male age is $avgMaleAge.";
 [toObject](docs/Operations.md#toobject),
 [unary](docs/Operations.md#unary)
 [union](docs/Operations.md#union),
-[unique](docs/Operations.md#unique),
+[unique / distinct](docs/Operations.md#unique--distinct),
 [values](docs/Operations.md#values)
 
 #### Jump to:

--- a/composer.json
+++ b/composer.json
@@ -102,6 +102,7 @@
 			"src/toObject.php",
 			"src/unary.php",
 			"src/union.php",
+			"src/unique.php",
 			"src/values.php",
 			"src/where.php",
 			"src/without.php",

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -83,7 +83,7 @@ Operation | Signature | Curried
 [toObject](#toobject) | `toObject($value): object` | `Curry\toObject`
 [unary](#unary) | `unary(callable $callable): callable` | `Curry\unary`
 [union](#union) | `union($iterable /*, ...iterables */): array` | 
-[unique](#unique) | `unique($iterable): array` | 
+[unique](#unique--distinct) / distinct | `unique($iterable): array` | 
 [values](#values) | `values($iterable): array` | `Curry\values`
 
 
@@ -3355,7 +3355,7 @@ Dash\union(
 
 [↑ Top](#operations)
 
-unique
+unique / distinct
 ---
 
 

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -83,6 +83,7 @@ Operation | Signature | Curried
 [toObject](#toobject) | `toObject($value): object` | `Curry\toObject`
 [unary](#unary) | `unary(callable $callable): callable` | `Curry\unary`
 [union](#union) | `union($iterable /*, ...iterables */): array` | 
+[unique](#unique) | `unique($iterable): array` | 
 [values](#values) | `values($iterable): array` | `Curry\values`
 
 
@@ -3350,6 +3351,38 @@ Dash\union(
 	['e' => 5, 'f' => 6]
 );
 // === ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6]
+```
+
+[↑ Top](#operations)
+
+unique
+---
+
+
+```php
+unique($iterable): array
+```
+Returns a new array containing the unique values, in order, of the provided iterable.
+
+Non-indexed keys are preseved, but duplicate keys will overwrite previous ones.
+
+
+Parameter | Type | Description
+--- | --- | :---
+`$iterable` | `iterable\|stdClass\|null` |
+**Returns** | `array` |
+
+**Example:** With indexed arrays
+```php
+Dash\unique([1, 2, 2, 3, 1]);
+// === [1, 2, 3]
+
+```
+
+**Example:** With associative arrays
+```php
+Dash\unique(['a' => 1, 'b' => 2, 'c' => 1]);
+// === ['a' => 1, 'b' => 2]
 ```
 
 [↑ Top](#operations)

--- a/src/unique.php
+++ b/src/unique.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Dash;
+
+/**
+ * Returns a new array containing the unique values, in order, of the provided iterable.
+ *
+ * Non-indexed keys are preseved, but duplicate keys will overwrite previous ones.
+ *
+ * @param iterable|stdClass|null $iterable
+ * @return array
+ *
+ * @example With indexed arrays
+	Dash\unique([1, 2, 2, 3, 1]);
+	// === [1, 2, 3]
+ *
+ * @example With associative arrays
+	Dash\unique(['a' => 1, 'b' => 2, 'c' => 1]);
+	// === ['a' => 1, 'b' => 2]
+ */
+function unique($iterable)
+{
+	assertType($iterable, ['iterable', 'stdClass', 'null'], __FUNCTION__);
+	return union($iterable);
+}

--- a/src/unique.php
+++ b/src/unique.php
@@ -10,6 +10,8 @@ namespace Dash;
  * @param iterable|stdClass|null $iterable
  * @return array
  *
+ * @alias distinct
+ *
  * @example With indexed arrays
 	Dash\unique([1, 2, 2, 3, 1]);
 	// === [1, 2, 3]
@@ -22,4 +24,9 @@ function unique($iterable)
 {
 	assertType($iterable, ['iterable', 'stdClass', 'null'], __FUNCTION__);
 	return union($iterable);
+}
+
+function distinct()
+{
+	return call_user_func_array('Dash\unique', func_get_args());
 }

--- a/tests/uniqueTest.php
+++ b/tests/uniqueTest.php
@@ -11,6 +11,7 @@ class uniqueTest extends PHPUnit_Framework_TestCase
 	public function test($iterable, $expected)
 	{
 		$this->assertSame($expected, Dash\unique($iterable));
+		$this->assertSame($expected, Dash\distinct($iterable));
 	}
 
 	public function cases()
@@ -219,6 +220,17 @@ class uniqueTest extends PHPUnit_Framework_TestCase
 	{
 		try {
 			Dash\unique($iterable);
+		}
+		catch (Exception $e) {
+			$this->assertSame(
+				"Dash\\unique expects iterable or stdClass or null but was given $type",
+				$e->getMessage()
+			);
+			throw $e;
+		}
+
+		try {
+			Dash\distinct($iterable);
 		}
 		catch (Exception $e) {
 			$this->assertSame(

--- a/tests/uniqueTest.php
+++ b/tests/uniqueTest.php
@@ -1,0 +1,278 @@
+<?php
+
+/**
+ * @covers Dash\unique
+ */
+class uniqueTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @dataProvider cases
+	 */
+	public function test($iterable, $expected)
+	{
+		$this->assertSame($expected, Dash\unique($iterable));
+	}
+
+	public function cases()
+	{
+		return [
+			'With nulls' => [
+				'iterable' => [null, null, null],
+				'expected' => [null],
+			],
+			'With empty iterable' => [
+				'iterable' => [],
+				'expected' => []
+			],
+
+			/*
+				With indexed array
+			 */
+
+			'With an indexed array with unique elements' => [
+				'iterable' => [
+					6,
+					1,
+					3,
+				],
+				'expected' => [6, 1, 3]
+			],
+			'With an indexed array with a mix of duplicate and unique elements' => [
+				'iterable' => [
+					4,
+					2,
+					1,
+					6,
+					3,
+					4,
+					5,
+					1,
+					3,
+					5,
+				],
+				'expected' => [4, 2, 1, 6, 3, 5]
+			],
+			'With an indexed array with fully duplicated elements' => [
+				'iterable' => [
+					1,
+					2,
+					2,
+					1,
+					2,
+					1,
+				],
+				'expected' => [1, 2]
+			],
+
+			/*
+				With associative array
+			 */
+
+			'With an associative array with unique values' => [
+				'iterable' => [
+					'a' => 6,
+					'b' => 5,
+					'c' => 1,
+					'd' => 2,
+					'e' => 3,
+					'f' => 4,
+				],
+				'expected' => ['a' => 6, 'b' => 5, 'c' => 1, 'd' => 2, 'e' => 3, 'f' => 4]
+			],
+			'With an associative array with a mix of duplicate and unique values' => [
+				'iterable' => [
+					'a' => 4,
+					'b' => 2,
+					'c' => 1,
+					3,
+					5,
+					1,
+					3,
+					5,
+				],
+				'expected' => ['a' => 4, 'b' => 2, 'c' => 1, 3, 5]
+			],
+			'With an associative array with fully duplictaed values' => [
+				'iterable' => [
+					'a' => 1,
+					'b' => 2,
+					'c' => 2,
+					'd' => 1,
+					'a' => 2,
+					'b' => 1,
+				],
+				'expected' => ['a' => 2, 'b' => 1]
+			],
+
+			/*
+				With stdClass
+			 */
+
+			'With an stdClass with unique values' => [
+				'iterable' => (object) [
+					'a' => 6,
+					'b' => 5,
+					'c' => 1,
+					'd' => 2,
+					'e' => 3,
+					'f' => 4,
+				],
+				'expected' => ['a' => 6, 'b' => 5, 'c' => 1, 'd' => 2, 'e' => 3, 'f' => 4]
+			],
+			'With an stdClass with a mix of duplicate and unique values' => [
+				'iterable' => (object) [
+					'a' => 4,
+					'b' => 2,
+					'c' => 1,
+					3,
+					5,
+					1,
+					3,
+					5,
+				],
+				'expected' => ['a' => 4, 'b' => 2, 'c' => 1, 3, 5]
+			],
+			'With an stdClass with fully duplicated values' => [
+				'iterable' => (object) [
+					'a' => 1,
+					'b' => 2,
+					'c' => 2,
+					'd' => 1,
+					'a' => 2,
+					'b' => 1,
+				],
+				'expected' => ['a' => 2, 'b' => 1]
+			],
+
+			/*
+				With ArrayObject
+			 */
+
+			'With an ArrayObject with non-intersecting iterables' => [
+				'iterable' => new ArrayObject([
+					'a' => 6,
+					'b' => 5,
+					'c' => 1,
+					'd' => 2,
+					'e' => 3,
+					'f' => 4,
+				]),
+				'expected' => ['a' => 6, 'b' => 5, 'c' => 1, 'd' => 2, 'e' => 3, 'f' => 4]
+			],
+			'With an ArrayObject with partially intersecting iterables' => [
+				'iterable' => new ArrayObject([
+					'a' => 4,
+					'b' => 2,
+					'c' => 1,
+					3,
+					5,
+					1,
+					3,
+					5,
+				]),
+				'expected' => ['a' => 4, 'b' => 2, 'c' => 1, 3, 5]
+			],
+			'With an ArrayObject with fully overlapping iterables' => [
+				'iterable' => new ArrayObject([
+					'a' => 1,
+					'b' => 2,
+					'c' => 2,
+					'd' => 1,
+					'a' => 2,
+					'b' => 1,
+				]),
+				'expected' => ['a' => 2, 'b' => 1]
+			],
+
+			/*
+				Special cases
+			 */
+
+			'Values are compared using loose equality' => [
+				'iterable' => [
+					1,
+					2,
+					3,
+					'2',
+					3.0,
+				],
+				'expected' => [1, 2, 3]
+			],
+			'Duplicate values with a mix of indexed and non-indexed keys are de-duped, and the first key wins' => [
+				'iterable' => [
+					'a' => 1,
+					'b' => 2,
+					1,
+					2,
+					3
+				],
+				'expected' => ['a' => 1, 'b' => 2, 2 => 3]
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider casesTypeAssertions
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testTypeAssertions($iterable, $type)
+	{
+		try {
+			Dash\unique($iterable);
+		}
+		catch (Exception $e) {
+			$this->assertSame(
+				"Dash\\unique expects iterable or stdClass or null but was given $type",
+				$e->getMessage()
+			);
+			throw $e;
+		}
+	}
+
+	public function casesTypeAssertions()
+	{
+		return [
+			'With an empty string' => [
+				'iterable' => '',
+				'type' => 'string',
+			],
+			'With a string' => [
+				'iterable' => 'hello',
+				'type' => 'string',
+			],
+			'With a zero number' => [
+				'iterable' => 0,
+				'type' => 'integer',
+			],
+			'With a number' => [
+				'iterable' => 3.14,
+				'type' => 'double',
+			],
+			'With a DateTime' => [
+				'iterable' => new DateTime(),
+				'type' => 'DateTime',
+			],
+		];
+	}
+
+	public function testExamples()
+	{
+		$this->assertSame(
+			[1, 3, 5, 2, 4, 6, 7, 8],
+			Dash\unique([
+				1, 3, 5,
+				2, 4, 6,
+				7, 8
+			])
+		);
+
+		$this->assertSame(
+			['a' => 1, 'c' => 3, 'b' => 2, 'd' => 4, 'e' => 5, 'f' => 6],
+			Dash\unique([
+				'a' => 1, 'c' => 3,
+				'b' => 2, 'd' => 4,
+				'e' => 5, 'f' => 6
+			])
+		);
+	}
+}


### PR DESCRIPTION
Add a simple `unique()` function to Dash to unique values in an iterable.

Notes:

- I copied the unit tests from `union` as a starting point.
- The implementation just turns around and calls `union()` with a single list.  However, I don't want that to matter.  I want a full battery of tests against `unique` so that we are free to refactor it, as needed.