### PR TITLE
PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - '7.0'
   - '7.1'
   - '7.2'
+  - '7.3'
 
 before_script:
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -174,7 +174,7 @@
 		]
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4.7",
+		"phpunit/phpunit": "^4.8",
 		"phpdocumentor/phpdocumentor": "^2.8",
 		"squizlabs/php_codesniffer": "^3.0"
 	}

--- a/composer.json
+++ b/composer.json
@@ -174,7 +174,7 @@
 		]
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^4.8",
+		"phpunit/phpunit": "^4.7",
 		"phpdocumentor/phpdocumentor": "^2.8",
 		"squizlabs/php_codesniffer": "^3.0"
 	}

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fee913a15a14108080472a5633192771",
+    "content-hash": "8c6929c928c112a428144e08be75535f",
     "packages": [],
     "packages-dev": [
         {
@@ -401,6 +401,7 @@
                 "schema",
                 "validate"
             ],
+            "abandoned": "kherge/json",
             "time": "2013-10-30T16:51:34+00:00"
         },
         {
@@ -458,6 +459,7 @@
                 "phar",
                 "update"
             ],
+            "abandoned": true,
             "time": "2013-10-30T17:23:01+00:00"
         },
         {
@@ -725,6 +727,7 @@
             ],
             "description": "A parsing and comparison library for semantic versioning.",
             "homepage": "http://github.com/kherge/Version",
+            "abandoned": true,
             "time": "2012-08-16T17:13:03+00:00"
         },
         {
@@ -1661,6 +1664,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c6929c928c112a428144e08be75535f",
+    "content-hash": "fee913a15a14108080472a5633192771",
     "packages": [],
     "packages-dev": [
         {
@@ -401,7 +401,6 @@
                 "schema",
                 "validate"
             ],
-            "abandoned": "kherge/json",
             "time": "2013-10-30T16:51:34+00:00"
         },
         {
@@ -459,7 +458,6 @@
                 "phar",
                 "update"
             ],
-            "abandoned": true,
             "time": "2013-10-30T17:23:01+00:00"
         },
         {
@@ -727,7 +725,6 @@
             ],
             "description": "A parsing and comparison library for semantic versioning.",
             "homepage": "http://github.com/kherge/Version",
-            "abandoned": true,
             "time": "2012-08-16T17:13:03+00:00"
         },
         {
@@ -1664,7 +1661,6 @@
                 "mock",
                 "xunit"
             ],
-            "abandoned": true,
             "time": "2015-10-02T06:51:40+00:00"
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
     "content-hash": "fee913a15a14108080472a5633192771",
@@ -2179,16 +2179,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.0.2",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "c7594a88ae75401e8f8d0bd4deb8431b39045c51"
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/c7594a88ae75401e8f8d0bd4deb8431b39045c51",
-                "reference": "c7594a88ae75401e8f8d0bd4deb8431b39045c51",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/0afebf16a2e7f1e434920fa976253576151effe9",
+                "reference": "0afebf16a2e7f1e434920fa976253576151effe9",
                 "shasum": ""
             },
             "require": {
@@ -2198,7 +2198,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
                 "bin/phpcs",
@@ -2221,12 +2221,12 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-07-18T01:12:32+00:00"
+            "time": "2019-09-26T23:12:26+00:00"
         },
         {
             "name": "symfony/config",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -126,6 +126,7 @@
 		<exclude name="PEAR.Commenting.FunctionComment.SpacingAfterParamName"/>
 		<exclude name="PEAR.Commenting.FunctionComment.Missing"/>
 		<exclude name="PEAR.Commenting.FunctionComment.MissingParamComment"/>
+		<exclude name="PEAR.Commenting.FunctionComment.ExtraParamComment" />
 	</rule>
 	<rule ref="PEAR.Commenting.InlineComment"/>
 	<rule ref="PEAR.ControlStructures.ControlSignature">


### PR DESCRIPTION
Note that PHP 7.2 and 7.3 show tons of warnings about `null` not being `Countable`, however, they do not break the build.

It's a known issue in this version of PHPUnit.  There is a fix, but the maintainer of PHPUnit is not interested in back-porting to PHPUnit 4.x or even 5.x.
https://github.com/sebastianbergmann/php-code-coverage/pull/554

PHPUnit 4.x PR: https://github.com/sebastianbergmann/php-code-coverage/pull/590
PHPUnit 5.x PR: https://github.com/sebastianbergmann/php-code-coverage/pull/591

So in order for tests to run perfectly clean under PHP 7.2 and 7.3, we need to upgrade PHPUnit to at least 6.x, which kills support for PHP 5.x (minimum supported: PHP 7.0)

I think we can live with the warnings for the time being, but should consider dropping support for older PHP versions in the near future.