### PR TITLE
Implement flatten function.  Closes mpetrovich/dash#10

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ echo "Average male age is $avgMaleAge.";
 [findLastValue](docs/Operations.md#findlastvalue),
 [findValue](docs/Operations.md#findvalue),
 [first / head](docs/Operations.md#first--head),
+[flatten](docs/Operations.md#flatten),
 [get](docs/Operations.md#get),
 [getDirect](docs/Operations.md#getdirect),
 [getDirectRef](docs/Operations.md#getdirectref),

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
 			"src/findLastValue.php",
 			"src/findValue.php",
 			"src/first.php",
+			"src/flatten.php",
 			"src/get.php",
 			"src/getDirect.php",
 			"src/getDirectRef.php",

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -1486,6 +1486,16 @@ Dash\flatten([['a' => 1, 'b' => 2], ['c' => 3]]);
 ```php
 Dash\flatten([1, 2, [3, 4]]);
 // === [1, 2, 3, 4]
+
+```
+
+**Example:** Deeply nested array
+```php
+Dash\flatten([
+	[1, 2],
+	[[3, 4]]
+]);
+// === [1, 2, [3, 4]]
 ```
 
 [↑ Top](#operations)

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -1464,9 +1464,7 @@ flatten($iterable): array
 ```
 Gets a list of nested elements in `$iterable`.
 
-Keys are preserved unless `$iterable` is an indexed array.
-An indexed array is one with sequential integer keys starting at zero. See [isIndexedArray()](#isindexedarray)
-When flattening an associative array, keys will point at the first value from a nested iterable.
+Keys in `$iterable` are not preserved.
 
 
 Parameter | Type | Description
@@ -1480,7 +1478,7 @@ Dash\flatten([[1, 2], [3, 4]]);
 // === [1, 2, 3, 4]
 
 Dash\flatten([['a' => 1, 'b' => 2], ['c' => 3]]);
-// === ['a' => 1, 'b' => 2, 'c' => 3]
+// === [1, 2, 3]
 
 ```
 
@@ -1488,20 +1486,6 @@ Dash\flatten([['a' => 1, 'b' => 2], ['c' => 3]]);
 ```php
 Dash\flatten([1, 2, [3, 4]]);
 // === [1, 2, 3, 4]
-
-```
-
-**Example:** Nested associative array, key preserved for first element.
-```php
-Dash\flatten([
-	'a' => [1, 2],
-	'b' => 3
-]);
-// === [
-	'a' => 1,
-	2
-	'b' => 3
-]
 ```
 
 [↑ Top](#operations)

--- a/docs/Operations.md
+++ b/docs/Operations.md
@@ -35,6 +35,7 @@ Operation | Signature | Curried
 [findLastValue](#findlastvalue) | `findLastValue($iterable, $predicate = 'Dash\identity'): mixed\|null` | `Curry\findLastValue`
 [findValue](#findvalue) | `findValue($iterable, $predicate = 'Dash\identity'): mixed\|null` | `Curry\findValue`
 [first](#first--head) / head | `first($iterable): mixed\|null` | `Curry\first`
+[flatten](#flatten) | `flatten($iterable): array` | 
 [get](#get) | `get($input, $path, $default = null): mixed` | `Curry\get`
 [getDirect](#getdirect) | `getDirect($input, $key, $default = null): mixed` | `Curry\getDirect`
 [getDirectRef](#getdirectref) | `getDirectRef(&$input, $key): mixed` | 
@@ -1450,6 +1451,57 @@ Dash\first(['a' => 'one', 'b' => 'two', 'c' => 'three']);
 
 Dash\first([]);
 // === null
+```
+
+[↑ Top](#operations)
+
+flatten
+---
+See also: `groupBy()`
+
+```php
+flatten($iterable): array
+```
+Gets a list of nested elements in `$iterable`.
+
+Keys are preserved unless `$iterable` is an indexed array.
+An indexed array is one with sequential integer keys starting at zero. See [isIndexedArray()](#isindexedarray)
+When flattening an associative array, keys will point at the first value from a nested iterable.
+
+
+Parameter | Type | Description
+--- | --- | :---
+`$iterable` | `iterable\|stdClass\|null` |
+**Returns** | `array` | List of elements in `$iterable`, including elements of directly nested iterables.
+
+**Example:**
+```php
+Dash\flatten([[1, 2], [3, 4]]);
+// === [1, 2, 3, 4]
+
+Dash\flatten([['a' => 1, 'b' => 2], ['c' => 3]]);
+// === ['a' => 1, 'b' => 2, 'c' => 3]
+
+```
+
+**Example:** With a mix of nested and non-nested iterables
+```php
+Dash\flatten([1, 2, [3, 4]]);
+// === [1, 2, 3, 4]
+
+```
+
+**Example:** Nested associative array, key preserved for first element.
+```php
+Dash\flatten([
+	'a' => [1, 2],
+	'b' => 3
+]);
+// === [
+	'a' => 1,
+	2
+	'b' => 3
+]
 ```
 
 [↑ Top](#operations)

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -22,6 +22,13 @@ namespace Dash;
  * @example With a mix of nested and non-nested iterables
 	Dash\flatten([1, 2, [3, 4]]);
 	// === [1, 2, 3, 4]
+ *
+ * @example Deeply nested array
+	Dash\flatten([
+		[1, 2],
+		[[3, 4]]
+	]);
+	// === [1, 2, [3, 4]]
  */
 function flatten($iterable)
 {

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -35,6 +35,6 @@ function flatten($iterable)
 	assertType($iterable, ['iterable', 'stdClass', 'null'], __FUNCTION__);
 
 	return reduce($iterable, function ($flattened, $value) {
-		return \array_merge($flattened, $value === null ? [null] : (array) $value);
+		return array_merge($flattened, is_array($value) ? array_values($value) : [$value]);
 	}, []);
 }

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Dash;
+
+/**
+ * Gets a list of nested elements in `$iterable`.
+ *
+ * Keys are preserved unless `$iterable` is an indexed array.
+ * An indexed array is one with sequential integer keys starting at zero. See [isIndexedArray()](#isindexedarray)
+ * When flattening an associative array, keys will point at the first value from a nested iterable.
+ *
+ * @see groupBy()
+ *
+ * @param iterable|stdClass|null $iterable
+ * @return array List of elements in `$iterable`, including elements of directly nested iterables.
+ *
+ * @example
+	Dash\flatten([[1, 2], [3, 4]]);
+	// === [1, 2, 3, 4]
+
+	Dash\flatten([['a' => 1, 'b' => 2], ['c' => 3]]);
+	// === ['a' => 1, 'b' => 2, 'c' => 3]
+ *
+ * @example With a mix of nested and non-nested iterables
+	Dash\flatten([1, 2, [3, 4]]);
+	// === [1, 2, 3, 4]
+ *
+ * @example Nested associative array, key preserved for first element.
+	Dash\flatten([
+		'a' => [1, 2],
+		'b' => 3
+	]);
+	// === [
+		'a' => 1,
+		2
+		'b' => 3
+	]
+ */
+function flatten($iterable)
+{
+	assertType($iterable, ['iterable', 'stdClass', 'null'], __FUNCTION__);
+
+	return reduce($iterable, function ($previous, $next, $key) {
+		if ($key != null && $next != null) {
+			$associativeArray = [];
+			$associativeArray[$key] = ((array) $next)[0];
+
+			$previous = \array_merge($previous, $associativeArray);
+			$next = takeRight((array) $next, -1);
+		}
+
+		return \array_merge($previous, $next === null ? [null] : (array) $next);
+	}, []);
+}

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -42,8 +42,10 @@ function flatten($iterable)
 
 	return reduce($iterable, function ($previous, $next, $key) {
 		if ($key != null && $next != null) {
+			$asArray = (array) $next;
+
 			$associativeArray = [];
-			$associativeArray[$key] = ((array) $next)[0];
+			$associativeArray[$key] = $asArray[0];
 
 			$previous = \array_merge($previous, $associativeArray);
 			$next = takeRight((array) $next, -1);

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -5,9 +5,7 @@ namespace Dash;
 /**
  * Gets a list of nested elements in `$iterable`.
  *
- * Keys are preserved unless `$iterable` is an indexed array.
- * An indexed array is one with sequential integer keys starting at zero. See [isIndexedArray()](#isindexedarray)
- * When flattening an associative array, keys will point at the first value from a nested iterable.
+ * Keys in `$iterable` are not preserved.
  *
  * @see groupBy()
  *
@@ -19,38 +17,17 @@ namespace Dash;
 	// === [1, 2, 3, 4]
 
 	Dash\flatten([['a' => 1, 'b' => 2], ['c' => 3]]);
-	// === ['a' => 1, 'b' => 2, 'c' => 3]
+	// === [1, 2, 3]
  *
  * @example With a mix of nested and non-nested iterables
 	Dash\flatten([1, 2, [3, 4]]);
 	// === [1, 2, 3, 4]
- *
- * @example Nested associative array, key preserved for first element.
-	Dash\flatten([
-		'a' => [1, 2],
-		'b' => 3
-	]);
-	// === [
-		'a' => 1,
-		2
-		'b' => 3
-	]
  */
 function flatten($iterable)
 {
 	assertType($iterable, ['iterable', 'stdClass', 'null'], __FUNCTION__);
 
-	return reduce($iterable, function ($previous, $next, $key) {
-		if ($key != null && $next != null) {
-			$asArray = (array) $next;
-
-			$associativeArray = [];
-			$associativeArray[$key] = $asArray[0];
-
-			$previous = \array_merge($previous, $associativeArray);
-			$next = takeRight((array) $next, -1);
-		}
-
+	return reduce($iterable, function ($previous, $next) {
 		return \array_merge($previous, $next === null ? [null] : (array) $next);
 	}, []);
 }

--- a/src/flatten.php
+++ b/src/flatten.php
@@ -27,7 +27,7 @@ function flatten($iterable)
 {
 	assertType($iterable, ['iterable', 'stdClass', 'null'], __FUNCTION__);
 
-	return reduce($iterable, function ($previous, $next) {
-		return \array_merge($previous, $next === null ? [null] : (array) $next);
+	return reduce($iterable, function ($flattened, $value) {
+		return \array_merge($flattened, $value === null ? [null] : (array) $value);
 	}, []);
 }

--- a/tests/flattenTest.php
+++ b/tests/flattenTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * @covers Dash\flatten
+ */
+class flattenTest extends PHPUnit_Framework_TestCase
+{
+	/**
+	 * @dataProvider cases
+	 */
+	public function test($iterable, $expected)
+	{
+		$this->assertSame($expected, Dash\flatten($iterable));
+	}
+
+	public function cases()
+	{
+		return [
+			'With nulls' => [
+				'iterable' => [null, null, null],
+				'expected' => [null, null, null],
+			],
+			'With empty iterable' => [
+				'iterable' => [],
+				'expected' => [],
+			],
+
+			/*
+				With indexed array
+			 */
+
+			'With an indexed array with only scalar values' => [
+				'iterable' => [
+					6,
+					1,
+					3,
+				],
+				'expected' => [6, 1, 3]
+			],
+			'With an indexed array with a mix of scalar and array values' => [
+				'iterable' => [
+					4,
+					[2, 3],
+					[7,9],
+					8,
+				],
+				'expected' => [4, 2, 3, 7, 9, 8]
+			],
+			'With an indexed array with only array values' => [
+				'iterable' => [
+					[2, 3],
+					[7,9],
+				],
+				'expected' => [2, 3, 7, 9]
+			],
+
+			/*
+				With associative array
+			 */
+
+			'With an associative array with only scalar values' => [
+				'iterable' => [
+					'a' => 6,
+					'b' => 1,
+					'c' => 3,
+				],
+				'expected' => ['a' => 6, 'b' => 1, 'c' => 3]
+			],
+			'With an associative array with a mix of scalar and array values' => [
+				'iterable' => [
+					'a' => 4,
+					'b' => [2, 3],
+					'c' => [7,9],
+					'd' => 8,
+				],
+				'expected' => ['a' => 4, 'b' => 2, 3, 'c' => 7, 9, 'd' => 8]
+			],
+			'With an associative array with only array values' => [
+				'iterable' => [
+					'b' => [2, 3],
+					'c' => [7,9],
+				],
+				'expected' => ['b' => 2, 3, 'c' => 7, 9]
+			],
+
+			/*
+				With stdClass
+			 */
+
+			'With an stdClass with only scalar values' => [
+				'iterable' => (object) [
+					'a' => 6,
+					'b' => 1,
+					'c' => 3,
+				],
+				'expected' => ['a' => 6, 'b' => 1, 'c' => 3]
+			],
+			'With an stdClass with a mix of scalar and array values' => [
+				'iterable' => (object) [
+					'a' => 4,
+					'b' => [2, 3],
+					'c' => [7,9],
+					'd' => 8,
+				],
+				'expected' => ['a' => 4, 'b' => 2, 3, 'c' => 7, 9, 'd' => 8]
+			],
+			'With an stdClass with only array values' => [
+				'iterable' => (object) [
+					'b' => [2, 3],
+					'c' => [7,9],
+				],
+				'expected' => ['b' => 2, 3, 'c' => 7, 9]
+			],
+
+			/*
+				With ArrayObject
+			 */
+
+			'With an ArrayObject with only scalar values' => [
+				'iterable' => new ArrayObject([
+					'a' => 6,
+					'b' => 1,
+					'c' => 3,
+				]),
+				'expected' => ['a' => 6, 'b' => 1, 'c' => 3]
+			],
+			'With an ArrayObject with a mix of scalar and array values' => [
+				'iterable' => new ArrayObject([
+					'a' => 4,
+					'b' => [2, 3],
+					'c' => [7,9],
+					'd' => 8,
+				]),
+				'expected' => ['a' => 4, 'b' => 2, 3, 'c' => 7, 9, 'd' => 8]
+			],
+			'With an ArrayObject with only array values' => [
+				'iterable' => new ArrayObject([
+					'b' => [2, 3],
+					'c' => [7,9],
+				]),
+				'expected' => ['b' => 2, 3, 'c' => 7, 9]
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider casesTypeAssertions
+	 * @expectedException InvalidArgumentException
+	 */
+	public function testTypeAssertions($iterable, $type)
+	{
+		try {
+			Dash\flatten($iterable);
+		}
+		catch (Exception $e) {
+			$this->assertSame(
+				"Dash\\flatten expects iterable or stdClass or null but was given $type",
+				$e->getMessage()
+			);
+			throw $e;
+		}
+	}
+
+	public function casesTypeAssertions()
+	{
+		return [
+			'With an empty string' => [
+				'iterable' => '',
+				'type' => 'string',
+			],
+			'With a string' => [
+				'iterable' => 'hello',
+				'type' => 'string',
+			],
+			'With a zero number' => [
+				'iterable' => 0,
+				'type' => 'integer',
+			],
+			'With a number' => [
+				'iterable' => 3.14,
+				'type' => 'double',
+			],
+			'With a DateTime' => [
+				'iterable' => new DateTime(),
+				'type' => 'DateTime',
+			],
+		];
+	}
+}

--- a/tests/flattenTest.php
+++ b/tests/flattenTest.php
@@ -139,6 +139,18 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'c' => [7,9],
 				]),
 				'expected' => [2, 3, 7, 9]
+			],
+
+			/*
+				Edge cases
+			 */
+
+			'With deeply nested arrays' => [
+				'iterable' => [
+					[1, 2],
+					[[3, 4]]
+				],
+				'expected' => [1, 2, [3, 4]]
 			]
 		];
 	}

--- a/tests/flattenTest.php
+++ b/tests/flattenTest.php
@@ -15,6 +15,9 @@ class flattenTest extends PHPUnit_Framework_TestCase
 
 	public function cases()
 	{
+		$stdClass = (object) ['c' => 10, 'd' => 11];
+		$arrayObject = new ArrayObject(['e' => 12, 'f' => 13]);
+
 		return [
 			'With nulls' => [
 				'iterable' => [null, null, null],
@@ -37,14 +40,16 @@ class flattenTest extends PHPUnit_Framework_TestCase
 				],
 				'expected' => [6, 1, 3]
 			],
-			'With an indexed array with a mix of scalar and array values' => [
+			'With an indexed array with a mix of scalar and non-scalar values' => [
 				'iterable' => [
 					4,
 					[2, 3],
-					[7,9],
+					['a' => 7, 'b' => 9],
+					$stdClass,
+					$arrayObject,
 					8,
 				],
-				'expected' => [4, 2, 3, 7, 9, 8]
+				'expected' => [4, 2, 3, 7, 9, $stdClass, $arrayObject, 8]
 			],
 			'With an indexed array with only array values' => [
 				'iterable' => [
@@ -66,14 +71,16 @@ class flattenTest extends PHPUnit_Framework_TestCase
 				],
 				'expected' => [ 6, 1, 3]
 			],
-			'With an associative array with a mix of scalar and array values' => [
+			'With an associative array with a mix of scalar and non-scalar values' => [
 				'iterable' => [
 					'a' => 4,
 					'b' => [2, 3],
-					'c' => [7,9],
-					'd' => 8,
+					'c' => ['a' => 7, 'b' => 9],
+					'd' => $stdClass,
+					'e' => $arrayObject,
+					'f' => 8,
 				],
-				'expected' => [4, 2, 3, 7, 9, 8]
+				'expected' => [4, 2, 3, 7, 9, $stdClass, $arrayObject, 8]
 			],
 			'With an associative array with only array values' => [
 				'iterable' => [
@@ -95,14 +102,16 @@ class flattenTest extends PHPUnit_Framework_TestCase
 				],
 				'expected' => [6, 1, 3]
 			],
-			'With an stdClass with a mix of scalar and array values' => [
+			'With an stdClass with a mix of scalar and non-scalar values' => [
 				'iterable' => (object) [
 					'a' => 4,
 					'b' => [2, 3],
-					'c' => [7,9],
-					'd' => 8,
+					'c' => ['a' => 7, 'b' => 9],
+					'd' => $stdClass,
+					'e' => $arrayObject,
+					'f' => 8,
 				],
-				'expected' => [4, 2, 3, 7, 9, 8]
+				'expected' => [4, 2, 3, 7, 9, $stdClass, $arrayObject, 8]
 			],
 			'With an stdClass with only array values' => [
 				'iterable' => (object) [
@@ -124,14 +133,16 @@ class flattenTest extends PHPUnit_Framework_TestCase
 				]),
 				'expected' => [6, 1, 3]
 			],
-			'With an ArrayObject with a mix of scalar and array values' => [
+			'With an ArrayObject with a mix of scalar and non-scalar values' => [
 				'iterable' => new ArrayObject([
 					'a' => 4,
 					'b' => [2, 3],
-					'c' => [7,9],
-					'd' => 8,
+					'c' => ['a' => 7, 'b' => 9],
+					'd' => $stdClass,
+					'e' => $arrayObject,
+					'f' => 8,
 				]),
-				'expected' => [4, 2, 3, 7, 9, 8]
+				'expected' => [4, 2, 3, 7, 9, $stdClass, $arrayObject, 8]
 			],
 			'With an ArrayObject with only array values' => [
 				'iterable' => new ArrayObject([

--- a/tests/flattenTest.php
+++ b/tests/flattenTest.php
@@ -64,7 +64,7 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'b' => 1,
 					'c' => 3,
 				],
-				'expected' => ['a' => 6, 'b' => 1, 'c' => 3]
+				'expected' => [ 6, 1, 3]
 			],
 			'With an associative array with a mix of scalar and array values' => [
 				'iterable' => [
@@ -73,14 +73,14 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'c' => [7,9],
 					'd' => 8,
 				],
-				'expected' => ['a' => 4, 'b' => 2, 3, 'c' => 7, 9, 'd' => 8]
+				'expected' => [4, 2, 3, 7, 9, 8]
 			],
 			'With an associative array with only array values' => [
 				'iterable' => [
 					'b' => [2, 3],
 					'c' => [7,9],
 				],
-				'expected' => ['b' => 2, 3, 'c' => 7, 9]
+				'expected' => [2, 3, 7, 9]
 			],
 
 			/*
@@ -93,7 +93,7 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'b' => 1,
 					'c' => 3,
 				],
-				'expected' => ['a' => 6, 'b' => 1, 'c' => 3]
+				'expected' => [6, 1, 3]
 			],
 			'With an stdClass with a mix of scalar and array values' => [
 				'iterable' => (object) [
@@ -102,14 +102,14 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'c' => [7,9],
 					'd' => 8,
 				],
-				'expected' => ['a' => 4, 'b' => 2, 3, 'c' => 7, 9, 'd' => 8]
+				'expected' => [4, 2, 3, 7, 9, 8]
 			],
 			'With an stdClass with only array values' => [
 				'iterable' => (object) [
 					'b' => [2, 3],
 					'c' => [7,9],
 				],
-				'expected' => ['b' => 2, 3, 'c' => 7, 9]
+				'expected' => [2, 3, 7, 9]
 			],
 
 			/*
@@ -122,7 +122,7 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'b' => 1,
 					'c' => 3,
 				]),
-				'expected' => ['a' => 6, 'b' => 1, 'c' => 3]
+				'expected' => [6, 1, 3]
 			],
 			'With an ArrayObject with a mix of scalar and array values' => [
 				'iterable' => new ArrayObject([
@@ -131,14 +131,14 @@ class flattenTest extends PHPUnit_Framework_TestCase
 					'c' => [7,9],
 					'd' => 8,
 				]),
-				'expected' => ['a' => 4, 'b' => 2, 3, 'c' => 7, 9, 'd' => 8]
+				'expected' => [4, 2, 3, 7, 9, 8]
 			],
 			'With an ArrayObject with only array values' => [
 				'iterable' => new ArrayObject([
 					'b' => [2, 3],
 					'c' => [7,9],
 				]),
-				'expected' => ['b' => 2, 3, 'c' => 7, 9]
+				'expected' => [2, 3, 7, 9]
 			]
 		];
 	}


### PR DESCRIPTION
Add the `flatten` operation to Dash.  This initial implementation is shallow.  We can make a deep flatten as a next step if that becomes useful too.

I modeled the behavior off [Lodash's `flatten` operation](https://lodash.com/docs/4.17.15#flatten), with some tweaks to work with PHP concepts like associative arrays.

The concept of flattening an associative array is sort of strange.  The behavior I selected is arbitrary because there is no precedent for such a thing.  I chose to preserve the key for the *first element* of an array that has been flattened, so that

`['a' => [1, 2, 3]]` flattens to `['a' => 1, 2, 3]`

I'm open to alternate behaviors.  Right now, this makes the most sense to me.