### PR TITLE
Fix dev environment - fix composer version, composer install deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - "8.0"
 
 before_script:
+    - composer self-update 2.1.6
     - composer install --no-interaction
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /usr/src/dash
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends git zip unzip libzip-dev
 RUN pecl install pcov
-COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/
+COPY --from=composer:2.1.6 /usr/bin/composer /usr/bin/
 RUN composer install
 
 RUN make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.4-fpm
-ENV DRIVER pcov
+ENV DRIVER=pcov
 
 COPY ./php.ini /usr/local/etc/php/php.ini
 COPY . /usr/src/dash
@@ -8,8 +8,8 @@ WORKDIR /usr/src/dash
 RUN apt-get update && \
     apt-get install --yes --no-install-recommends git zip unzip libzip-dev
 RUN pecl install pcov
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-RUN composer update --with-all-dependencies
+COPY --from=composer:2.8.5 /usr/bin/composer /usr/bin/
+RUN composer install
 
 RUN make
-CMD make test
+CMD ["make", "test"]


### PR DESCRIPTION
I've noticed the dev environment won't run anymore due to two issues:

1. `composer update` tries to update to an incompatible set of packages -> fixed by switching to `composer install`
2. `composer install` using the latest version of composer fails, so I downgraded to the lowest composer version that still works -> downgrade to composer:2.8.5
     ```
    Fatal error: Declaration of Symfony\Flex\Command\UpdateCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Composer\Command\UpdateCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /usr/src/dash/vendor/symfony/flex/src/Command/UpdateCommand.php on line 31
    ```

I also fixed a few docker deprecations in the Dockerfile.

These fixes should unblock future fixes.